### PR TITLE
Added two missing layout engines/programs

### DIFF
--- a/lib/pydotplus/graphviz.py
+++ b/lib/pydotplus/graphviz.py
@@ -448,7 +448,9 @@ def __find_executables(path):
         'neato': '',
         'circo': '',
         'fdp': '',
-        'sfdp': ''
+        'sfdp': '',
+        'osage': '',
+        'patchwork': '',
     }
 
     was_quoted = False


### PR DESCRIPTION
I added two missing layout programs that come with Graphviz: `osage` and `patchwork`. 
- [Patchwork](http://www.graphviz.org/pdf/patchwork.1.pdf) is used for creating a tree-view of a cluster graph with nodes represented as tiles.
- [Osage](http://www.graphviz.org/pdf/osage.1.pdf) is used for drawing cluster graphs

Since I'm using Anaconda as my python distribution, I can't run tests using Tox as the testing framework. The people with Anaconda and Tox are working on figuring compatibility out right now, but it's still a work in progress. After adding the two lines in this pull request to the programs pydotplus tries to find when searching for graphviz executables, things seem to be working well.

I've tried the fix with the following code (using networkx to construct the graph and converting to pydotplus), and building up the graph in pydotplus manually in an Ipython session (which I forgot to export) and both worked fine. 

```
import networkx as nx
g = nx.DiGraph()
g.add_path(('A','R','F','B','R'))
g.add_path(('A','C','G','B','R'))
for l in ('A','B','C','D','E','F','R'):
    g.add_edge('A',l)

gdot = nx.drawing.nx_pydot.to_pydot(g)

with open('test-patchwork.jpg','wb') as f:
    f.write(gdot.create_jpg(f='jpg',prog='patchwork'))

with open('test-osage.jpg','wb') as f:
    f.write(gdot.create_jpg(f='jpg',prog='osage'))
```

Here's an example with patchwork: 
![test-patchwork](https://cloud.githubusercontent.com/assets/10916106/18610640/4f158116-7cef-11e6-90cd-f141a43f9507.jpg)

It's not the best example, but here's with osage:
![test-osage](https://cloud.githubusercontent.com/assets/10916106/18644949/4557daee-7e79-11e6-9a54-a5600ad80a02.jpg)
#### Regarding a potential future pull request

I may add two more programs in a later pull request: `ccomps` which converts disconnected components to subgraphs; and `gvpack` which can arrange the sub graphs in an array. Neither of these however are strictly speaking layout programs (I don't believe), and operate on the graph directly. [Here's an example of how](http://stackoverflow.com/questions/8002352/how-to-control-subgraphs-layout-in-dot)  I would be looking to use them. 

But I'll need to look more into
1. The easiest way to pipe output from different programs into each other using pydotplus, or what would be needed to support that. 
2. Getting a test environment for any such changes set up on another laptop.
before considering adding those. 
