### PR TITLE
Make graphviz module compatible with graphviz conda package

### DIFF
--- a/lib/pydotplus/graphviz.py
+++ b/lib/pydotplus/graphviz.py
@@ -478,6 +478,14 @@ def __find_executables(path):
 
                 success = True
 
+            elif os.path.exists(os.path.join(path, prg + '.bat')):
+                if was_quoted:
+                    progs[prg] = '"' + os.path.join(path, prg + '.bat') + '"'
+                else:
+                    progs[prg] = os.path.join(path, prg + '.bat')
+
+                success = True
+
     if success:
         return progs
     else:


### PR DESCRIPTION
The graphviz conda package adds .bat chims for dot.exe and others. This makes pydotplus able to find graphviz installed with conda.